### PR TITLE
Make tag vars optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 # https://login.tailscale.com/admin/settings/authkeys
 tailscale_authkey: "{{ lookup('env','TAILSCALE_AUTHKEY') }}"
 tailscale_args: '--shields-up'
-
+tailscale_tags: []
 # subnet router only enable when you know what we'll be into!!
 # https://tailscale.com/kb/1019/subnets/
 tailscale_router: false

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -129,13 +129,13 @@
 
 - name: Connect machine to tailscale
   command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags {{ tailscale_tag_set }}"
-  no_log: true
   when:
     - status.rc|int != 0
-    - not tailscale_router
+    - not tailscale_router|bool
     - not authorization.failed
   register: tailscale_node
   changed_when: tailscale_node.rc|int == 0
+  #no_log: true
 
 - name: Setup
   when: tailscale_router|bool
@@ -151,13 +151,13 @@
 
 - name: Connect subnet router to tailscale
   command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-routes={{ tailscale_routes }} --advertise-tags {{ tailscale_tag_set }} {{ tailscale_args }}"
-  no_log: true
+#  no_log: true
   when:
     - status.rc|int != 0
     - tailscale_router|bool
     - not authorization.failed
-  register: tailscale_router
-  changed_when: tailscale_router.rc|int == 0
+  register: router_status
+  changed_when: router_status.rc|int == 0
 
 - name: Check ip address
   command: tailscale ip

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -122,13 +122,13 @@
     verbosity: 2
 
 - set_fact:
-    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list | join(',') }}"
+    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list }}"
 - debug:
     var: tailscale_tag_set
     verbosity: 1
 
 - name: Connect machine to tailscale
-  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags '{{ tailscale_tag_set }}'"
+  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags '{{ tailscale_tag_set  | join(',') }}'"
   when:
     - status.rc|int != 0
     - not tailscale_router|bool

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -132,7 +132,7 @@
     tailscale_ip: "{{ ip_check.stdout_lines[0] }}"
 
 - name: Check status
-  command: tailscale status
+  command: "tailscale status | grep {{inventory_hostname}}"
   changed_when: false
   failed_when: status.rc|int > 1
   register: status_check
@@ -140,5 +140,5 @@
 - name: Display tailscale_ip
   debug:
     msg: "{{ status_check.stdout_lines }}"
-    verbosity: 2
+    verbosity: 1
 ...

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -110,7 +110,7 @@
     verbosity: 2
 
 - set_fact:
-    union_tag_set: "{{ standard_tag_set | union(tailscale_tags) }}"
+    union_tag_set: "{{ standard_tag_set | union(tailscale_tags_tag_set) }}"
 - debug:
     var: union_tag_set
     verbosity: 2

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -98,10 +98,10 @@
       - "tag:{{ tag_cloud }}"
 - debug:
     var: standard_tag_set
-    verbosity: 1
+    verbosity: 2
 - debug:
     var: tailscale_tags
-    verbosity: 1
+    verbosity: 2
 
 - set_fact:
     tailscale_tags_tag_set: "{{ tailscale_tags | list | map('regex_replace','^(tag:)?(.+)$','tag:\\2') }}"
@@ -122,13 +122,13 @@
     verbosity: 2
 
 - set_fact:
-    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list }}"
+    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list | join(',') }}"
 - debug:
     var: tailscale_tag_set
-    verbosity: 1
+    verbosity: 2
 
 - name: Connect machine to tailscale
-  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags '{{ tailscale_tag_set  | join(',') }}'"
+  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags '{{ tailscale_tag_set }}'"
   when:
     - status.rc|int != 0
     - not tailscale_router|bool

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -122,13 +122,13 @@
     verbosity: 2
 
 - set_fact:
-    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list }}"
+    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list | join(',') }}"
 - debug:
     var: tailscale_tag_set
     verbosity: 1
 
 - name: Connect machine to tailscale
-  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags {{ tailscale_tag_set }}"
+  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags '{{ tailscale_tag_set }}'"
   when:
     - status.rc|int != 0
     - not tailscale_router|bool

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -116,7 +116,7 @@
     verbosity: 2
 
 - set_fact:
-    tailscale_tag_map: "{{ union_tag_set | zip(union_tag_set|map('replace', ':', '_')) }}"
+    tailscale_tag_map: "{{ dict(union_tag_set | zip(union_tag_set|map('replace', ':', '_'))) }}"
 - debug:
     var: tailscale_tag_map
     verbosity: 2

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -89,11 +89,31 @@
   changed_when: false
 
 - set_fact:
-    standard_tag_set:
-      - "tag:{{ tag_environment }}"
-      - "tag:{{ tag_type }}"
-      - "tag:{{ tag_chain }}"
-      - "tag:{{ tag_network }}"
+    standard_tag_set: []
+
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_environment }}'] }}"
+  when: tag_environment is defined
+
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_type }}'] }}"
+  when: tag_type is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_chain }}'] }}"
+  when: tag_chain is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_network }}'] }}"
+  when: tag_network is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_region }}'] }}"
+  when: tag_region is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_cloud }}'] }}"
+  when: tag_cloud is defined
 - debug:
     var: standard_tag_set
     verbosity: 2

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -139,5 +139,6 @@
 
 - name: Display tailscale_ip
   debug:
-     msg: "{{ status_check.stdout_lines }}"
+    msg: "{{ status_check.stdout_lines }}"
+    verbosity: 2
 ...

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -88,8 +88,47 @@
   failed_when: status.rc|int > 1
   changed_when: false
 
+- set_fact:
+    standard_tag_set:
+      - "tag:{{ tag_environment }}"
+      - "tag:{{ tag_type }}"
+      - "tag:{{ tag_chain }}"
+      - "tag:{{ tag_network }}"
+      - "tag:{{ tag_region }}"
+      - "tag:{{ tag_cloud }}"
+- debug:
+    var: standard_tag_set
+    verbosity: 1
+- debug:
+    var: tailscale_tags
+    verbosity: 1
+
+- set_fact:
+    tailscale_tags_tag_set: "{{ tailscale_tags | list | map('regex_replace','^(tag:)?(.+)$','tag:\\2') }}"
+- debug:
+    var: tailscale_tags_tag_set
+    verbosity: 2
+
+- set_fact:
+    union_tag_set: "{{ standard_tag_set | union(tailscale_tags) }}"
+- debug:
+    var: union_tag_set
+    verbosity: 2
+
+- set_fact:
+    tailscale_tag_map: "{{ union_tag_set | zip(union_tag_set|map('replace', ':', '_')) }}"
+- debug:
+    var: tailscale_tag_map
+    verbosity: 2
+
+- set_fact:
+    tailscale_tag_set: "{{ tailscale_tag_map.keys() | list }}"
+- debug:
+    var: tailscale_tag_set
+    verbosity: 1
+
 - name: Connect machine to tailscale
-  command: "tailscale up -authkey {{ tailscale_authkey }}"
+  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-tags {{ tailscale_tag_set }}"
   no_log: true
   when:
     - status.rc|int != 0
@@ -111,7 +150,7 @@
     - 'net.ipv6.conf.all.forwarding'
 
 - name: Connect subnet router to tailscale
-  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-routes={{ tailscale_routes }} {{ tailscale_args }}"
+  command: "tailscale up -authkey {{ tailscale_authkey }} --advertise-routes={{ tailscale_routes }} --advertise-tags {{ tailscale_tag_set }} {{ tailscale_args }}"
   no_log: true
   when:
     - status.rc|int != 0

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -94,8 +94,6 @@
       - "tag:{{ tag_type }}"
       - "tag:{{ tag_chain }}"
       - "tag:{{ tag_network }}"
-      - "tag:{{ tag_region }}"
-      - "tag:{{ tag_cloud }}"
 - debug:
     var: standard_tag_set
     verbosity: 2


### PR DESCRIPTION
Currently the role requires the following vars populated
```
        tag_environment: "production"
        tag_type: "full"
        tag_chain: "fantom"
        tag_network: "mainnet"
        tag_region: "fra"
        tag_cloud: "oracle"
```
This makes the unusable on non-chain nodes

Updating so that it will use tag vars only if provided.